### PR TITLE
fix: initialize Mike versioning for GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,10 +62,22 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Fetch gh-pages branch
+      - name: Initialize gh-pages branch if needed
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          git fetch origin gh-pages --depth=1 || true
+          # Check if gh-pages branch exists
+          if ! git ls-remote --heads origin gh-pages | grep -q gh-pages; then
+            echo "Creating gh-pages branch..."
+            git checkout --orphan gh-pages
+            git rm -rf .
+            echo "# GitHub Pages" > README.md
+            git add README.md
+            git commit -m "Initialize gh-pages branch"
+            git push origin gh-pages
+            git checkout main
+          else
+            git fetch origin gh-pages --depth=1
+          fi
 
       - name: Deploy development documentation
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -73,8 +85,14 @@ jobs:
           # Deploy main branch docs as 'dev' version
           mike deploy --push --update-aliases dev
           
-          # Ensure latest is still the default
-          mike set-default --push latest || mike set-default --push dev
+          # Deploy current stable version if VERSION file exists
+          if [ -f VERSION ]; then
+            VERSION=$(cat VERSION)
+            mike deploy --push --update-aliases "$VERSION" latest stable
+            mike set-default --push latest
+          else
+            mike set-default --push dev
+          fi
 
       - name: Build documentation for PR preview
         if: github.event_name == 'pull_request'
@@ -86,4 +104,21 @@ jobs:
         with:
           name: docs-preview
           path: ./site
+
+      - name: Configure GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          echo "📝 GitHub Pages Configuration Notes:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "After this workflow completes, please configure GitHub Pages:" >> $GITHUB_STEP_SUMMARY
+          echo "1. Go to Settings → Pages" >> $GITHUB_STEP_SUMMARY
+          echo "2. Change Source from 'Deploy from a branch'" >> $GITHUB_STEP_SUMMARY
+          echo "3. Select Branch: **gh-pages**" >> $GITHUB_STEP_SUMMARY
+          echo "4. Select Folder: **/ (root)**" >> $GITHUB_STEP_SUMMARY
+          echo "5. Click Save" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The versioned documentation will then be available at:" >> $GITHUB_STEP_SUMMARY
+          echo "- Latest stable: https://jayminwest.github.io/kota-db/" >> $GITHUB_STEP_SUMMARY
+          echo "- Development: https://jayminwest.github.io/kota-db/dev/" >> $GITHUB_STEP_SUMMARY
+          echo "- Version 0.2.0: https://jayminwest.github.io/kota-db/0.2.0/" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
## Summary
- Initialize gh-pages branch for Mike versioning
- Configure automated deployment of versioned documentation
- Deploy both development and stable versions

## Problem
Issue #63 identified that while the Mike versioning code was merged in PR #65, it wasn't actually working on the live GitHub Pages site because:
1. The gh-pages branch didn't exist
2. GitHub Pages was configured to use main branch instead of gh-pages
3. Mike requires a gh-pages branch to manage versions properly

## Solution
This PR updates the docs workflow to:
1. Automatically create gh-pages branch if it doesn't exist
2. Deploy development docs from main as 'dev' version
3. Deploy stable version (0.2.0) with 'latest' and 'stable' aliases
4. Set proper default version for the version selector
5. Provide instructions for configuring GitHub Pages to use gh-pages branch

## Testing
After this PR is merged:
1. The workflow will create the gh-pages branch
2. GitHub Pages needs to be manually configured to use gh-pages branch
3. The version selector will appear on the documentation site
4. Users can switch between dev, latest, and specific versions

## Related Issues
Fixes #63

🤖 Generated with [Claude Code](https://claude.ai/code)