### PR TITLE
fix: resolve document size limit bug - increase from ~1MB to 100MB (#103, #105)

### DIFF
--- a/docs/api/api_reference.md
+++ b/docs/api/api_reference.md
@@ -435,6 +435,25 @@ api_key_required = false
 rate_limit_per_minute = 1000
 ```
 
+## Constraints and Limitations
+
+### Document Size Limits
+- **Maximum document size**: 100MB
+- **Maximum path length**: 4,096 characters
+- **Maximum title length**: 1,024 characters
+- **Maximum tag length**: 256 characters per tag
+- **Maximum tags per document**: 100
+
+### Search Limitations
+- **Maximum query length**: 1,024 characters
+- **Trigram indexing**: Applied to first 1MB of document content
+- **Default result limit**: 50 documents (configurable)
+
+### Performance Considerations
+- Documents larger than 10MB may experience slower indexing
+- Bulk operations are recommended for inserting more than 100 documents
+- Connection pool size defaults to 100 concurrent connections
+
 ## Performance Characteristics
 
 | Operation | Latency Target | Throughput | Notes |


### PR DESCRIPTION
## Summary
Fixes critical bug where KotaDB HTTP server was rejecting documents larger than ~1MB with HTTP 413 errors. This was caused by Axum's default body size limit.

**Issues resolved:** #103, #105

## Changes Made

### Core Fix
- ✅ Added `DefaultBodyLimit::max(100MB)` middleware to both HTTP server creation functions
- ✅ Added `MAX_DOCUMENT_SIZE` constant (100MB) for centralized configuration
- ✅ Added startup logging to inform users of the maximum document size

### Testing & Quality
- ✅ Added comprehensive test for 5MB document upload to verify fix works
- ✅ All existing tests continue to pass (89 unit tests, 10+ integration tests)
- ✅ No performance impact - limit is enforced at middleware layer

### Documentation
- ✅ Updated API reference with new "Constraints and Limitations" section
- ✅ Documented 100MB document size limit and other system constraints

## Technical Details

**Root Cause:** Axum's `Json` extractor has a default body limit that was causing HTTP 413 errors for documents around 1MB.

**Solution:** Applied `DefaultBodyLimit::max(MAX_DOCUMENT_SIZE)` middleware to both:
- `create_server()` 
- `create_server_with_pool()`

**Design Decisions:**
- Set limit to 100MB as reasonable balance between functionality and abuse prevention
- Kept existing 1MB limit for trigram text indexing (sufficient for search purposes)
- Added centralized constant for easy configuration changes
- Preserved all existing validation and safety mechanisms

## Test Plan
- [x] Unit test with 5MB document creation succeeds
- [x] All existing HTTP server tests pass
- [x] Integration tests confirm no regressions
- [x] Server startup logs maximum document size

## Impact
- ✅ **Fixes blocking issue** for users with documents >1MB
- ✅ **No breaking changes** - purely expands functionality
- ✅ **Performance neutral** - middleware adds negligible overhead
- ✅ **Well documented** - users know the limits upfront

🤖 Generated with [Claude Code](https://claude.ai/code)