### PR TITLE
fix: Resolve critical API issues #149 and #150

### DIFF
--- a/clients/python/kotadb/client.py
+++ b/clients/python/kotadb/client.py
@@ -127,7 +127,7 @@ class KotaDB:
         except requests.RequestException as e:
             raise ConnectionError(f"Request failed: {e}") from e
 
-    def query(self, query: str, limit: Optional[int] = None, offset: int = 0) -> QueryResult:
+    def query(self, query: str, limit: Optional[int] = None, offset: int = 0, **kwargs) -> QueryResult:
         """
         Search documents using text query.
 
@@ -135,6 +135,7 @@ class KotaDB:
             query: Search query string
             limit: Maximum number of results to return
             offset: Number of results to skip
+            **kwargs: Additional filter parameters (e.g., tag, path)
 
         Returns:
             QueryResult with matching documents and metadata
@@ -144,6 +145,9 @@ class KotaDB:
             params["limit"] = limit
         if offset:
             params["offset"] = offset
+        
+        # Add any additional filter parameters
+        params.update(kwargs)
 
         response = self._make_request("GET", "/documents/search", params=params)
         return QueryResult.from_dict(response.json())


### PR DESCRIPTION
## Summary
- Fixed issue #150: `list_all()` returning 0 documents despite successful insertions
- Fixed issue #149: QueryBuilder filters failing with 'unexpected keyword argument' errors
- Both issues were blocking core API functionality

## Changes

### Issue #150: list_all() returns 0 documents
**Root Cause**: Route ordering issue - `/documents/search` was defined after `/documents/:id`, causing "search" to be interpreted as an ID parameter.

**Fix**: Moved `/documents/search` route before parameterized routes in the routing configuration.

**Result**: GET `/documents` endpoint now correctly returns all documents.

### Issue #149: QueryBuilder filters fail
**Root Cause**: Python client's `query()` method only accepted `limit` and `offset` parameters, rejecting filter parameters generated by QueryBuilder.

**Fixes**:
1. Modified Python client's `query()` method to accept `**kwargs` for additional filter parameters
2. Implemented server-side filtering logic for tags and paths
3. Added support for both 'tag' (from QueryBuilder) and 'tags' (server expectation) parameters
4. Implemented wildcard pattern matching for path filters (e.g., `rust/*`)

## Testing
- ✅ All existing unit tests pass (108 passed)
- ✅ Created comprehensive test scripts for both issues
- ✅ Verified `list_all()` correctly returns documents
- ✅ Verified QueryBuilder filters (tag, path) work as expected
- ✅ Pre-commit checks pass (formatting, clippy, tests)

## Test Results
```
Testing list_all() issue #150
✓ Issue fixed: list_all() returns documents correctly

Testing QueryBuilder filters (issue #149)
✓ Basic query works! Found 10 documents
✓ Tag filter works! Found 6 Python documents  
✓ Path filter works! Found 6 Rust documents
✓ Combined filters work! Found 5 Rust programming documents
```

Fixes #149
Fixes #150

🤖 Generated with [Claude Code](https://claude.ai/code)