### PR TITLE
fix(git): extract repository name from remote URL instead of showing 'unknown' (#193)

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -55,20 +55,15 @@ impl GitRepository {
             revwalk.push_head()?;
             let commit_count = revwalk.count();
 
-            // Get repository name from path
-            let name = self
-                .path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("unknown")
-                .to_string();
-
             // Try to get remote URL
             let url = self
                 .repo
                 .find_remote("origin")
                 .ok()
                 .and_then(|remote| remote.url().map(String::from));
+
+            // Extract repository name with multiple fallback strategies
+            let name = self.extract_repository_name(&url);
 
             Ok(RepositoryMetadata {
                 name,
@@ -84,6 +79,73 @@ impl GitRepository {
         #[cfg(not(feature = "git-integration"))]
         {
             anyhow::bail!("Git integration feature not enabled");
+        }
+    }
+
+    /// Extract repository name from remote URL or fall back to directory name
+    fn extract_repository_name(&self, url: &Option<String>) -> String {
+        // First, try to extract from remote URL if available
+        if let Some(remote_url) = url {
+            if let Some(name) = Self::parse_repository_name_from_url(remote_url) {
+                return name;
+            }
+        }
+
+        // Fall back to directory name
+        self.path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown-repository")
+            .to_string()
+    }
+
+    /// Parse repository name from various Git URL formats
+    fn parse_repository_name_from_url(url: &str) -> Option<String> {
+        // Handle SSH URLs: git@github.com:user/repo.git
+        if url.starts_with("git@") {
+            if let Some(path_part) = url.split(':').nth(1) {
+                return Self::extract_name_from_path(path_part);
+            }
+        }
+
+        // Handle HTTPS URLs: https://github.com/user/repo.git
+        if url.starts_with("http://") || url.starts_with("https://") {
+            // Remove protocol and find path
+            if let Some(path_start) = url.find("://") {
+                let path = &url[path_start + 3..];
+                // Skip domain and get path
+                if let Some(slash_pos) = path.find('/') {
+                    let repo_path = &path[slash_pos + 1..];
+                    return Self::extract_name_from_path(repo_path);
+                }
+            }
+        }
+
+        // Handle file:// URLs
+        if let Some(path) = url.strip_prefix("file://") {
+            return path
+                .split('/')
+                .next_back()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+        }
+
+        None
+    }
+
+    /// Extract repository name from path component (handles user/repo.git format)
+    fn extract_name_from_path(path: &str) -> Option<String> {
+        // Get the last component of the path (repo.git or repo)
+        let name = path.split('/').next_back().filter(|s| !s.is_empty())?;
+
+        // Remove .git extension if present
+        let name = name.strip_suffix(".git").unwrap_or(name);
+
+        // Ensure the name is not empty
+        if !name.is_empty() {
+            Some(name.to_string())
+        } else {
+            None
         }
     }
 
@@ -371,5 +433,100 @@ mod tests {
         assert!(result.is_err()); // Feature not enabled
 
         Ok(())
+    }
+
+    #[test]
+    fn test_parse_repository_name_from_github_https() {
+        let url = "https://github.com/jayminwest/kota-db.git";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, Some("kota-db".to_string()));
+    }
+
+    #[test]
+    fn test_parse_repository_name_from_github_ssh() {
+        let url = "git@github.com:jayminwest/kota-db.git";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, Some("kota-db".to_string()));
+    }
+
+    #[test]
+    fn test_parse_repository_name_from_gitlab_https() {
+        let url = "https://gitlab.com/someuser/my-project.git";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, Some("my-project".to_string()));
+    }
+
+    #[test]
+    fn test_parse_repository_name_from_gitlab_ssh() {
+        let url = "git@gitlab.com:someuser/my-project.git";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, Some("my-project".to_string()));
+    }
+
+    #[test]
+    fn test_parse_repository_name_without_git_extension() {
+        let url = "https://github.com/user/repo-without-extension";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, Some("repo-without-extension".to_string()));
+    }
+
+    #[test]
+    fn test_parse_repository_name_from_bitbucket() {
+        let url = "https://bitbucket.org/team/project.git";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, Some("project".to_string()));
+    }
+
+    #[test]
+    fn test_parse_repository_name_from_custom_domain() {
+        let url = "https://git.company.com/internal/private-repo.git";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, Some("private-repo".to_string()));
+    }
+
+    #[test]
+    fn test_parse_repository_name_from_file_url() {
+        let url = "file:///home/user/repos/local-repo";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, Some("local-repo".to_string()));
+    }
+
+    #[test]
+    fn test_parse_repository_name_with_nested_path() {
+        let url = "https://github.com/org/team/subteam/deep-repo.git";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, Some("deep-repo".to_string()));
+    }
+
+    #[test]
+    fn test_parse_repository_name_invalid_url() {
+        let url = "not-a-valid-url";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, None);
+    }
+
+    #[test]
+    fn test_parse_repository_name_empty_url() {
+        let url = "";
+        let name = GitRepository::parse_repository_name_from_url(url);
+        assert_eq!(name, None);
+    }
+
+    #[test]
+    fn test_extract_name_from_path() {
+        assert_eq!(
+            GitRepository::extract_name_from_path("user/repo.git"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            GitRepository::extract_name_from_path("org/team/project"),
+            Some("project".to_string())
+        );
+        assert_eq!(
+            GitRepository::extract_name_from_path("simple-name.git"),
+            Some("simple-name".to_string())
+        );
+        assert_eq!(GitRepository::extract_name_from_path(""), None);
+        assert_eq!(GitRepository::extract_name_from_path("/"), None);
     }
 }


### PR DESCRIPTION
## Summary
- Fixes repository name detection to extract from git remote URLs
- Supports multiple URL formats (SSH, HTTPS, file://)
- Falls back to directory name when no remote is available

## Problem
During git repository ingestion, the repository name was displayed as "unknown" instead of extracting the actual repository name from Git metadata. This made debugging and logging difficult.

## Solution
Implemented a multi-tier fallback strategy for repository name extraction:
1. **Primary**: Extract from git remote URL (most accurate)
2. **Secondary**: Use directory name (for local repos)
3. **Fallback**: Use "unknown-repository" (more descriptive than "unknown")

## Changes
- Added `extract_repository_name()` method with smart URL parsing
- Added `parse_repository_name_from_url()` to handle various Git URL formats
- Added `extract_name_from_path()` helper for path parsing
- Comprehensive test coverage with 12 new unit tests

## Supported URL Formats
- SSH: `git@github.com:user/repo.git` → "repo"
- HTTPS: `https://github.com/user/repo.git` → "repo"
- GitLab: `https://gitlab.com/user/repo.git` → "repo"
- Bitbucket: `https://bitbucket.org/team/repo.git` → "repo"
- Custom domains: `https://git.company.com/repo.git` → "repo"
- File URLs: `file:///path/to/repo` → "repo"
- Nested paths: `https://github.com/org/team/repo.git` → "repo"

## Testing
- ✅ All existing tests pass
- ✅ 12 new unit tests for URL parsing
- ✅ Code formatted with `cargo fmt`
- ✅ Clippy warnings resolved
- ✅ Pre-commit checks passed

## Test Coverage
```bash
cargo test --lib git::repository::tests --features git-integration
# 13 tests pass
```

Fixes #193