### PR TITLE
fix(query-sanitization): preserve asterisks for wildcard search functionality

### DIFF
--- a/tests/wildcard_search_test.rs
+++ b/tests/wildcard_search_test.rs
@@ -1,0 +1,249 @@
+// Integration tests for wildcard search functionality
+// Verifies that wildcard patterns work correctly through the entire query pipeline
+
+use anyhow::Result;
+use kotadb::{create_file_storage, DocumentBuilder, Index, QueryBuilder, Storage};
+use tempfile::TempDir;
+
+// Helper to create test storage and index
+async fn create_test_environment() -> Result<(impl Storage, impl Index, TempDir)> {
+    let temp_dir = TempDir::new()?;
+    let db_path = temp_dir.path().to_str().unwrap();
+
+    // Ensure directories exist
+    let storage_path = format!("{db_path}/storage");
+    let index_path = format!("{db_path}/index");
+
+    std::fs::create_dir_all(&storage_path)?;
+    std::fs::create_dir_all(&index_path)?;
+    std::fs::create_dir_all(format!("{storage_path}/documents"))?;
+    std::fs::create_dir_all(format!("{storage_path}/indices"))?;
+    std::fs::create_dir_all(format!("{storage_path}/wal"))?;
+    std::fs::create_dir_all(format!("{storage_path}/meta"))?;
+
+    let storage = create_file_storage(&storage_path, Some(100)).await?;
+    let index = kotadb::create_primary_index_for_tests(&index_path).await?;
+
+    Ok((storage, index, temp_dir))
+}
+
+#[tokio::test]
+async fn test_wildcard_search_end_to_end() -> Result<()> {
+    let (mut storage, mut index, _temp_dir) = create_test_environment().await?;
+
+    // Create test documents with various patterns
+    let test_docs = vec![
+        ("UserController.rs", "User controller implementation"),
+        ("AuthController.rs", "Authentication controller"),
+        ("test_user.rs", "User tests"),
+        ("test_auth.rs", "Authentication tests"),
+        ("main.rs", "Main application entry"),
+        ("lib.rs", "Library exports"),
+        ("AdminPanel.tsx", "Admin panel component"),
+        ("UserPanel.tsx", "User panel component"),
+    ];
+
+    for (path, title) in test_docs {
+        let doc = DocumentBuilder::new()
+            .path(path)?
+            .title(title)?
+            .content(format!("Content for {}", path).as_bytes())
+            .build()?;
+
+        storage.insert(doc.clone()).await?;
+        index.insert(doc.id, doc.path.clone()).await?;
+    }
+
+    // Test wildcard patterns
+
+    // Test 1: Suffix wildcard - find all controllers
+    let query = QueryBuilder::new().with_text("*Controller.rs")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 2, "Should find 2 Controller files");
+
+    // Test 2: Prefix wildcard - find all test files
+    let query = QueryBuilder::new().with_text("test_*")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 2, "Should find 2 test files");
+
+    // Test 3: Extension wildcard - find all Rust files
+    let query = QueryBuilder::new().with_text("*.rs")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 6, "Should find 6 .rs files");
+
+    // Test 4: Extension wildcard - find all TypeScript files
+    let query = QueryBuilder::new().with_text("*.tsx")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 2, "Should find 2 .tsx files");
+
+    // Test 5: Middle wildcard pattern
+    let query = QueryBuilder::new().with_text("*Panel.tsx")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 2, "Should find 2 Panel files");
+
+    // Test 6: Pure wildcard - find all documents
+    let query = QueryBuilder::new().with_text("*")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 8, "Should find all 8 documents");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_wildcard_sanitization_preservation() -> Result<()> {
+    // Test that wildcards are preserved through the sanitization process
+
+    // Test various wildcard patterns
+    let patterns = vec![
+        "*",
+        "*test",
+        "test*",
+        "*test*",
+        "prefix*suffix",
+        "*.rs",
+        "*Controller",
+        "test_*_function",
+    ];
+
+    for pattern in patterns {
+        let query = QueryBuilder::new().with_text(pattern)?.build()?;
+        // Check that path_pattern contains the wildcard
+        assert!(
+            query
+                .path_pattern
+                .as_ref()
+                .map(|p| p.contains('*'))
+                .unwrap_or(false)
+                || query.search_terms.iter().any(|t| t.as_str().contains('*')),
+            "Wildcard should be preserved in pattern: {}",
+            pattern
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_wildcard_with_special_characters() -> Result<()> {
+    let (mut storage, mut index, _temp_dir) = create_test_environment().await?;
+
+    // Create documents with special characters
+    let test_docs = vec![
+        ("test_user_controller.rs", "Test user controller"),
+        ("test-auth-controller.rs", "Test auth controller"),
+        ("user_profile_test.rs", "User profile test"),
+        ("auth-token-test.rs", "Auth token test"),
+    ];
+
+    for (path, title) in test_docs {
+        let doc = DocumentBuilder::new()
+            .path(path)?
+            .title(title)?
+            .content(format!("Content for {}", path).as_bytes())
+            .build()?;
+
+        storage.insert(doc.clone()).await?;
+        index.insert(doc.id, doc.path.clone()).await?;
+    }
+
+    // Test underscore patterns
+    let query = QueryBuilder::new().with_text("test_*")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 1, "Should find files starting with test_");
+
+    // Test hyphen patterns
+    let query = QueryBuilder::new().with_text("test-*")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 1, "Should find files starting with test-");
+
+    // Test mixed patterns
+    let query = QueryBuilder::new().with_text("*_test.rs")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 1, "Should find files ending with _test.rs");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_empty_wildcard_results() -> Result<()> {
+    let (mut storage, mut index, _temp_dir) = create_test_environment().await?;
+
+    // Create a single document
+    let doc = DocumentBuilder::new()
+        .path("test.txt")?
+        .title("Test document")?
+        .content(b"Test content")
+        .build()?;
+
+    storage.insert(doc.clone()).await?;
+    index.insert(doc.id, doc.path.clone()).await?;
+
+    // Search for non-existent patterns
+    let query = QueryBuilder::new().with_text("*.rs")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 0, "Should find no .rs files");
+
+    let query = QueryBuilder::new().with_text("*Controller*")?.build()?;
+    let results = index.search(&query).await?;
+    assert_eq!(results.len(), 0, "Should find no Controller files");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_wildcard_with_dangerous_chars_removed() -> Result<()> {
+    // Test that dangerous characters are removed while wildcards are preserved
+    let query = QueryBuilder::new()
+        .with_text("*test<script>alert('xss')</script>*")?
+        .build()?;
+
+    // Check that wildcards are preserved but dangerous content is removed
+    let has_wildcard = query
+        .path_pattern
+        .as_ref()
+        .map(|p| p.contains('*'))
+        .unwrap_or(false)
+        || query.search_terms.iter().any(|t| t.as_str().contains('*'));
+    assert!(has_wildcard, "Asterisks should be preserved");
+
+    let full_text = query
+        .search_terms
+        .iter()
+        .map(|t| t.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        !full_text.contains("<script>"),
+        "Script tags should be removed"
+    );
+    assert!(
+        !full_text.contains("alert"),
+        "Script content should be removed"
+    );
+
+    // Test LDAP injection characters (except asterisk)
+    let query = QueryBuilder::new()
+        .with_text("test*(admin)=value")?
+        .build()?;
+
+    // Check that asterisk is preserved but other LDAP chars are removed
+    let has_wildcard = query
+        .path_pattern
+        .as_ref()
+        .map(|p| p.contains('*'))
+        .unwrap_or(false)
+        || query.search_terms.iter().any(|t| t.as_str().contains('*'));
+    assert!(has_wildcard, "Asterisk should be preserved");
+
+    let full_text = query
+        .search_terms
+        .iter()
+        .map(|t| t.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(!full_text.contains('('), "Parentheses should be removed");
+    assert!(!full_text.contains(')'), "Parentheses should be removed");
+    assert!(!full_text.contains('='), "Equals should be removed");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Fixes #250 - Wildcard query sanitization was incorrectly removing asterisks, breaking wildcard search functionality
- Modified LDAP injection patterns to exclude asterisks while maintaining security
- Enhanced QueryBuilder to properly route wildcard patterns to the path_pattern field

## Changes
1. **Query Sanitization** (`src/query_sanitization.rs`)
   - Removed asterisk from LDAP injection pattern regex
   - Updated term extraction logic to properly validate wildcard patterns
   - Preserved security by continuing to sanitize other dangerous characters

2. **Query Builder** (`src/builders.rs`)  
   - Added wildcard detection logic in build() method
   - Routes queries containing asterisks to path_pattern field instead of search_terms
   - Maintains backward compatibility for non-wildcard queries

3. **Comprehensive Testing** (`tests/wildcard_search_test.rs`)
   - Added 5 test scenarios covering various wildcard patterns
   - Tests preservation through sanitization pipeline
   - Validates dangerous character removal while preserving wildcards

## Test Plan
- [x] Unit tests for wildcard preservation in sanitization
- [x] Integration tests for end-to-end wildcard search
- [x] Tests for mixed wildcard/dangerous character handling
- [x] All existing tests pass
- [x] Quality checks (fmt, clippy, tests) pass

## Impact
- Wildcard searches like `*Controller`, `test_*`, and `*.rs` now work correctly
- Primary index wildcard search capability is fully restored
- No breaking changes to existing functionality
- Security maintained - SQL injection, XSS, and other LDAP chars still blocked

## Example Usage
```rust
// Now works correctly:
let query = QueryBuilder::new().with_text("*Controller.rs")?.build()?;
let results = index.search(&query).await?;  // Finds all Controller files

let query = QueryBuilder::new().with_text("test_*")?.build()?;  
let results = index.search(&query).await?;  // Finds all test_ prefixed files
```

🤖 Generated with [Claude Code](https://claude.ai/code)