### PR TITLE
fix(docs): correct Python client directory name in verification

### DIFF
--- a/src/documentation_verification.rs
+++ b/src/documentation_verification.rs
@@ -598,7 +598,7 @@ impl DocumentationVerifier {
         let pyproject_path = python_dir.join("pyproject.toml");
         let setup_path = python_dir.join("setup.py");
         let src_path = python_dir.join("src");
-        let package_path = python_dir.join("kotadb_client");
+        let package_path = python_dir.join("kotadb");
 
         let has_setup = pyproject_path.exists() || setup_path.exists();
         let has_source = src_path.exists() || package_path.exists();
@@ -607,7 +607,7 @@ impl DocumentationVerifier {
             info!("Python client missing setup files (pyproject.toml or setup.py)");
         }
         if !has_source {
-            info!("Python client missing source directory (src/ or kotadb_client/)");
+            info!("Python client missing source directory (src/ or kotadb/)");
         }
 
         Ok(has_setup && has_source)


### PR DESCRIPTION
## Summary
Quick fix for Python client verification false negative - changes directory check from `kotadb_client` to `kotadb`

## Problem
The documentation verification was incorrectly reporting the Python client as missing when it actually exists and is fully functional. This was causing:
- False critical errors in documentation verification
- Documentation accuracy score lowered to 63%
- Misleading information about project completeness

## Root Cause
Simple naming mismatch in `src/documentation_verification.rs`:
- Looking for: `kotadb_client/` (with underscore)
- Actual name: `kotadb/` (without underscore)

## Solution
Updated two lines in `documentation_verification.rs`:
- Line 601: Changed `python_dir.join("kotadb_client")` to `python_dir.join("kotadb")`
- Line 610: Updated info message to reflect correct directory name

## Testing
- [x] Python client now correctly detected as existing
- [x] Documentation verification passes for Python client
- [x] All 175 unit tests pass
- [x] No regressions in other verification checks

## Before/After
**Before:**
```
❌ Python Client Library [CRITICAL]
   Reality: Python client directory not found or incomplete
```

**After:**
```
✅ Python Client Library
   Reality: Python client exists with proper local structure
```

Fixes #251

🤖 Generated with [Claude Code](https://claude.ai/code)