### PR TITLE
fix: symbol storage path mismatch and improve extraction transparency (#267, #269, #268)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -215,12 +215,13 @@ just docker-shell      # Connect to development container
 When working on search, indexing, or git features, consider testing on KotaDB itself:
 
 ### Quick Setup
-1. **Create temporary config**: Copy `kotadb-dev.toml` to `kotadb-dogfood.toml`
-2. **Change data directory**: Set data path to `data/analysis/` in the config
-3. **Test on real codebase**: `cargo run -- --config kotadb-dogfood.toml git-ingest .`
-4. **Validate functionality**: Run searches and queries to test your changes
-5. **Document findings**: Create GitHub issues for any problems discovered
-6. **Clean up**: Delete config and data directory when done
+1. **Use separate data directory**: Create `data/analysis/` for dogfooding tests
+2. **Test on real codebase**: `cargo run --bin kotadb -- -d ./data/analysis ingest-repo .`
+3. **Verify symbol extraction**: `cargo run --bin kotadb -- -d ./data/analysis symbol-stats`
+4. **Test relationship queries**: `cargo run --bin kotadb -- -d ./data/analysis find-callers FileStorage`
+5. **Validate functionality**: Run searches and queries to test your changes
+6. **Document findings**: Create GitHub issues for any problems discovered
+7. **Clean up**: Delete analysis data directory when done
 
 ### Why Dogfood?
 Real-world testing on KotaDB's own codebase consistently reveals integration issues that unit tests miss:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,13 +107,15 @@ The release process automatically:
 cargo build
 cargo build --release  # Production build
 
-# Run the main server with configuration
-cargo run -- --config kotadb-dev.toml
+# Run the main binary with custom database path
+cargo run --bin kotadb -- -d ./kota-db-data stats    # Show database statistics
+cargo run --bin kotadb -- -d ./kota-db-data search "rust"   # Full-text search (trigram index)
+cargo run --bin kotadb -- -d ./kota-db-data search "*"      # Wildcard search (primary index)
 
-# Run with specific commands
-cargo run stats              # Show database statistics
-cargo run search "rust"      # Full-text search (trigram index)
-cargo run search "*"         # Wildcard search (primary index)
+# Repository ingestion with symbol extraction
+cargo run --bin kotadb -- -d ./kota-db-data ingest-repo .   # Default: extracts symbols
+cargo run --bin kotadb -- -d ./kota-db-data ingest-repo . --no-symbols  # Skip symbol extraction
+cargo run --bin kotadb -- -d ./kota-db-data symbol-stats    # Check extracted symbols
 
 # Development server with auto-reload
 just dev                     # Uses cargo watch for auto-reload
@@ -240,12 +242,13 @@ Model Context Protocol server for LLM integration:
 
 ### Dogfooding for Validation
 When working on search, indexing, or git features, test on KotaDB itself:
-- **Create temporary config**: Copy existing config to `kotadb-dogfood.toml`
-- **Use separate data**: Set data directory to `data/analysis/` in config
-- **Test real complexity**: `cargo run -- --config kotadb-dogfood.toml git-ingest .`
+- **Use separate data directory**: Create a dedicated directory for analysis
+- **Test real complexity**: `cargo run --bin kotadb -- -d ./data/analysis ingest-repo .`
+- **Validate symbol extraction**: `cargo run --bin kotadb -- -d ./data/analysis symbol-stats`
+- **Test relationship queries**: `cargo run --bin kotadb -- -d ./data/analysis find-callers FileStorage`
 - **Validate your changes**: Run searches and performance tests on actual codebase
 - **Document issues found**: Create GitHub issues for any problems discovered
-- **Clean up artifacts**: Delete config and analysis data (never commit)
+- **Clean up artifacts**: Delete analysis data directory when done (never commit)
 
 This approach has consistently revealed integration issues missed by unit tests (see issues #191, #196, #184).
 


### PR DESCRIPTION
## Summary
This PR fixes three critical issues discovered during dogfooding that were preventing the relationship query feature from working properly:

- ✅ **Issue #267**: Fixed symbol storage path mismatch - queries now find extracted symbols
- ✅ **Issue #269**: Added symbol extraction transparency with CLI flags and feedback
- ✅ **Issue #268**: Corrected all documentation with proper CLI usage

## Changes

### 🔧 Issue #267 - Symbol Storage Path Fix
- Changed `create_relationship_engine()` to look in `symbol_storage` subdirectory instead of `storage`
- This fixes the mismatch where 16,831+ symbols were extracted but couldn't be found
- Relationship queries (`find-callers`, `impact-analysis`) now work correctly

### 📊 Issue #269 - Symbol Extraction Transparency
**Added CLI flags:**
- `--extract-symbols` - Explicitly enable symbol extraction
- `--no-symbols` - Skip symbol extraction for faster ingestion
- Default behavior: extraction enabled when tree-sitter feature is available

**Added feedback during ingestion:**
- Shows whether symbol extraction is enabled/disabled
- Reports symbol count in final statistics
- Displays symbols by type and language

**New command:**
- `symbol-stats` - Check extracted symbols without manual file system navigation
- Shows total symbols, breakdown by type/language, and dependency graph stats

### 📚 Issue #268 - Documentation Fixes
- Replaced all incorrect `--config` flag usage with `-d/--db-path`
- Updated dogfooding instructions in CLAUDE.md and AGENT.md
- Added examples for new symbol-related commands

## Testing
- ✅ All unit tests passing (175 passed)
- ✅ `cargo fmt` - clean
- ✅ `cargo clippy` - no warnings
- ✅ Pre-commit hooks passing

## Impact
These fixes make the relationship query feature functional and discoverable. Users can now:
1. Successfully query code relationships
2. See what's happening during symbol extraction
3. Follow documentation examples correctly

## Closes
- Fixes #267
- Fixes #269
- Fixes #268

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>