### PR TITLE
fix: resolve over-aggressive query sanitization blocking programming terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Target: Achieve <10ms query latency (previously 580ms)
 
 ### Fixed
+- CLI text search functionality for programming-related terms (#345)
+  - Fixed over-aggressive query sanitization that blocked legitimate search terms
+  - Words like "script", "javascript", "select", "insert", "create" now work correctly
+  - Made SQL injection protection more precise to target actual injection patterns
+  - Preserved security against real SQL injection and XSS attacks
 - CLI logging verbosity issues that impacted agent/LLM workflows (#335)
   - Changed default logging level from DEBUG to WARN for cleaner output
   - Eliminated excessive trace output that buried useful information

--- a/src/query_sanitization.rs
+++ b/src/query_sanitization.rs
@@ -23,9 +23,9 @@ const MIN_TERM_LENGTH: usize = 1;
 /// Reserved characters that could be used in injection attempts
 const RESERVED_CHARS: &[char] = &['<', '>', '&', '"', '\'', '\0', '\r', '\n', '\t'];
 
-/// SQL injection patterns to detect and block
+/// SQL injection patterns to detect and block - targeting actual injection syntax, not individual keywords
 static SQL_INJECTION_PATTERNS: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?i)(union|select|insert|update|delete|drop|create|alter|exec|execute|script|javascript|eval|onload|onerror|onclick|<script|<iframe|<object|<embed|<link|../|..\\)")
+    Regex::new(r"(?i)(\bunion\s+select\b|\bselect\s+.+\s+from\b|\binsert\s+into\b|\bupdate\s+.+\s+set\b|\bdelete\s+from\b|\bdrop\s+table\b|\bcreate\s+table\b|\balter\s+table\b|exec\(|execute\(|<script|<iframe|<object|<embed|<link|../|..\\|;\s*(select|insert|update|delete|drop|create|alter))")
         .expect("Failed to compile SQL injection regex")
 });
 

--- a/tests/query_sanitization_fix_test.rs
+++ b/tests/query_sanitization_fix_test.rs
@@ -1,0 +1,220 @@
+// Test to ensure query sanitization doesn't block legitimate programming terms
+// Addresses issue #345: CLI text search functionality not working for trigram queries
+
+use anyhow::Result;
+use kotadb::query_sanitization::sanitize_search_query;
+
+#[test]
+fn test_legitimate_programming_terms_allowed() -> Result<()> {
+    // Test that common programming terms are not blocked by sanitization
+    let terms = [
+        "rust",
+        "script",
+        "javascript",
+        "typescript",
+        "select",
+        "insert",
+        "update",
+        "delete",
+        "create",
+        "drop",
+        "alter",
+        "union",
+        "exec",
+        "execute",
+        "eval",
+    ];
+
+    for term in &terms {
+        let result = sanitize_search_query(term)?;
+        assert!(
+            !result.is_empty(),
+            "Term '{}' should not be empty after sanitization",
+            term
+        );
+        assert_eq!(
+            result.text.trim(),
+            *term,
+            "Term '{}' should be preserved",
+            term
+        );
+        assert!(
+            !result.was_modified,
+            "Term '{}' should not be modified",
+            term
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_multi_word_programming_queries_allowed() -> Result<()> {
+    let queries = [
+        "rust programming",
+        "javascript function",
+        "create component",
+        "select element",
+        "insert data",
+        "script tag",
+    ];
+
+    for query in &queries {
+        let result = sanitize_search_query(query)?;
+        assert!(
+            !result.is_empty(),
+            "Query '{}' should not be empty after sanitization",
+            query
+        );
+        assert_eq!(
+            result.text.trim(),
+            *query,
+            "Query '{}' should be preserved",
+            query
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_actual_sql_injection_blocked() -> Result<()> {
+    // Test that actual SQL injection patterns are still blocked
+    let malicious_queries = [
+        "union select * from users",
+        "select * from passwords",
+        "insert into admin values",
+        "update users set password",
+        "delete from important_table",
+        "drop table users",
+        "create table backdoor",
+        "alter table users add",
+        "; drop table users",
+    ];
+
+    for query in &malicious_queries {
+        let result = sanitize_search_query(query);
+        // These should either fail validation or be heavily sanitized
+        match result {
+            Ok(sanitized) => {
+                assert!(
+                    sanitized.is_empty() || sanitized.was_modified,
+                    "Malicious query '{}' should be blocked or modified",
+                    query
+                );
+            }
+            Err(_) => {
+                // It's ok if these fail entirely
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_html_injection_still_blocked() -> Result<()> {
+    let malicious_html = [
+        "<script>alert('xss')</script>",
+        "<iframe src='evil.com'></iframe>",
+        "<object data='malware.exe'></object>",
+    ];
+
+    for query in &malicious_html {
+        let result = sanitize_search_query(query)?;
+        assert!(
+            result.is_empty()
+                || !result.text.contains("<script") && !result.text.contains("<iframe"),
+            "HTML injection '{}' should be blocked",
+            query
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_issue_345_original_failing_cases() -> Result<()> {
+    // Test the exact cases from issue #345 that were failing
+    let test_cases = ["rust programming", "rust", "programming"];
+
+    for query in &test_cases {
+        let result = sanitize_search_query(query)?;
+        assert!(
+            !result.is_empty(),
+            "Query '{}' from issue #345 should work",
+            query
+        );
+        assert_eq!(result.text, *query, "Query '{}' should be unchanged", query);
+        assert!(
+            !result.was_modified,
+            "Query '{}' should not be modified",
+            query
+        );
+        assert!(
+            result.warnings.is_empty(),
+            "Query '{}' should have no warnings",
+            query
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use kotadb::{
+        create_binary_trigram_index, create_file_storage, DocumentBuilder, Index, QueryBuilder,
+        Storage,
+    };
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_end_to_end_search_with_programming_terms() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let storage_path = temp_dir.path().join("storage");
+        let index_path = temp_dir.path().join("trigram_index");
+
+        // Create storage and index
+        let mut storage = create_file_storage(storage_path.to_str().unwrap(), Some(100)).await?;
+        let mut index =
+            create_binary_trigram_index(index_path.to_str().unwrap(), Some(100)).await?;
+
+        // Insert test document
+        let doc = DocumentBuilder::new()
+            .path("test/script.md")?
+            .title("Script Testing")?
+            .content(b"This document contains javascript and script content for testing rust programming")
+            .build()?;
+
+        storage.insert(doc.clone()).await?;
+        index
+            .insert_with_content(doc.id, doc.path.clone(), &doc.content)
+            .await?;
+
+        // Test queries that were failing in issue #345
+        let test_queries = ["script", "javascript", "rust", "programming"];
+
+        for query_text in &test_queries {
+            let query = QueryBuilder::new()
+                .with_text(*query_text)?
+                .with_limit(10)?
+                .build()?;
+
+            let results = index.search(&query).await?;
+            assert!(
+                !results.is_empty(),
+                "Search for '{}' should find the document",
+                query_text
+            );
+            assert!(
+                results.contains(&doc.id),
+                "Search for '{}' should find our test document",
+                query_text
+            );
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Fixes CLI text search functionality that was failing for programming-related terms due to over-aggressive query sanitization. Resolves issue #345.

### Problem
- CLI search queries for programming terms like "script", "javascript", "select", "insert", "create" were failing
- Error: "Query became empty after sanitization"
- SQL injection protection was too broad, removing legitimate search terms instead of just dangerous patterns

### Root Cause Analysis
The `SQL_INJECTION_PATTERNS` regex in `src/query_sanitization.rs` was removing individual keywords rather than targeting actual SQL injection syntax patterns:

**Before (Problematic Pattern):**
```regex
(?i)(union|select|insert|update|delete|drop|create|alter|exec|execute|script|javascript|eval|onload|onerror|onclick|<script|<iframe|<object|<embed|<link|../|..\\)
```

This blocked legitimate searches for:
- Programming languages: `script`, `javascript`  
- SQL commands in documentation: `select`, `insert`, `create`
- Common development terms: `update`, `delete`, `execute`

### Solution
Updated the regex to target actual injection patterns while preserving individual programming terms:

**After (Precise Pattern):**
```regex
(?i)(\bunion\s+select\b|\bselect\s+.+\s+from\b|\binsert\s+into\b|\bupdate\s+.+\s+set\b|\bdelete\s+from\b|\bdrop\s+table\b|\bcreate\s+table\b|\balter\s+table\b|exec\(|execute\(|<script|<iframe|<object|<embed|<link|../|..\\|;\s*(select|insert|update|delete|drop|create|alter))
```

Key improvements:
- Uses word boundaries (`\b`) and context patterns
- Requires SQL syntax context (e.g., "SELECT ... FROM" not just "select")
- Still blocks HTML injection and path traversal
- Preserves security against real threats

### Testing

#### Manual Verification ✅
```bash
# These now work correctly:
./target/release/kotadb search "script"     # ✅ Returns results
./target/release/kotadb search "javascript" # ✅ Returns results  
./target/release/kotadb search "create"     # ✅ Returns results

# Security still works:
./target/release/kotadb search "union select * from users" # ❌ Blocked correctly
```

#### Comprehensive Test Suite ✅
Added `tests/query_sanitization_fix_test.rs` with:
- **Programming terms validation**: All affected keywords work correctly
- **Multi-word queries**: "rust programming", "javascript function" work
- **Security preservation**: SQL injection attempts still blocked
- **HTML injection protection**: XSS attempts still blocked  
- **Integration testing**: End-to-end search functionality verified

### Files Changed
- `src/query_sanitization.rs` - Updated SQL injection pattern
- `tests/query_sanitization_fix_test.rs` - Added comprehensive regression tests  
- `CHANGELOG.md` - Documented the fix

### Quality Assurance ✅
- All 221 unit tests pass
- New regression tests pass (6/6)
- Code formatting and linting clean
- No performance impact
- Security validation confirmed

### Impact
This fix enables KotaDB users to search for common programming terms in their codebases - critical functionality for a codebase intelligence platform. The solution maintains robust security while restoring expected search capabilities.

**Ready for merge!** 🚀

🤖 Generated with [Claude Code](https://claude.ai/code)