### PR TITLE
test: add failing test case for issue #368 - trigram index population

### DIFF
--- a/tests/test_trigram_issue_368.rs
+++ b/tests/test_trigram_issue_368.rs
@@ -1,0 +1,107 @@
+// Test for issue #368 - Trigram index not populated during repository ingestion
+// This test currently FAILS, demonstrating the issue
+use anyhow::Result;
+use kotadb::*;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn test_trigram_index_population_after_rebuild() -> Result<()> {
+    // Setup test environment
+    let temp_dir = TempDir::new()?;
+    let storage_path = temp_dir.path().join("storage");
+    let primary_path = temp_dir.path().join("primary");
+    let trigram_path = temp_dir.path().join("trigram");
+
+    // Create storage
+    let mut storage = create_file_storage(storage_path.to_str().unwrap(), Some(100)).await?;
+
+    // Create indices
+    let mut primary_index = create_primary_index(primary_path.to_str().unwrap(), Some(100)).await?;
+    let mut trigram_index = create_trigram_index(trigram_path.to_str().unwrap(), Some(100)).await?;
+
+    // Create test documents
+    for i in 0..5 {
+        let doc = DocumentBuilder::new()
+            .path(format!("test{}.md", i))?
+            .title(format!("Test Document {}", i))?
+            .content(format!("This is test content number {}. It contains various words like function, struct, impl, and let.", i).as_bytes())
+            .build()?;
+
+        storage.insert(doc.clone()).await?;
+    }
+
+    // Test trigram index before rebuild - should be empty
+    let text_query = QueryBuilder::new()
+        .with_text("test")?
+        .with_limit(10)?
+        .build()?;
+    let trigram_results_before = trigram_index.search(&text_query).await?;
+    assert_eq!(
+        trigram_results_before.len(),
+        0,
+        "Trigram index should be empty before rebuild"
+    );
+
+    // Rebuild indices with content
+    let all_docs = storage.list_all().await?;
+    assert_eq!(all_docs.len(), 5, "Should have 5 documents in storage");
+
+    // Rebuild primary index
+    for doc in &all_docs {
+        primary_index
+            .insert(doc.id, ValidatedPath::new(doc.path.to_string())?)
+            .await?;
+    }
+
+    // Rebuild trigram index WITH CONTENT (this is the critical part)
+    for doc in &all_docs {
+        trigram_index
+            .insert_with_content(
+                doc.id,
+                ValidatedPath::new(doc.path.to_string())?,
+                &doc.content,
+            )
+            .await?;
+    }
+
+    // Flush indices
+    primary_index.flush().await?;
+    trigram_index.flush().await?;
+
+    // Test primary index after rebuild
+    let wildcard_query = QueryBuilder::new().with_limit(10)?.build()?;
+    let primary_results = primary_index.search(&wildcard_query).await?;
+    assert_eq!(
+        primary_results.len(),
+        5,
+        "Primary index should have 5 documents"
+    );
+
+    // Test trigram index after rebuild - should now have results
+    let trigram_results_after = trigram_index.search(&text_query).await?;
+    assert!(
+        !trigram_results_after.is_empty(),
+        "Trigram index should have results after rebuild with content"
+    );
+    assert_eq!(
+        trigram_results_after.len(),
+        5,
+        "All 5 documents should match 'test'"
+    );
+
+    // Test other search terms
+    for term in &["function", "struct", "impl", "content"] {
+        let query = QueryBuilder::new()
+            .with_text(*term)?
+            .with_limit(10)?
+            .build()?;
+        let results = trigram_index.search(&query).await?;
+        assert!(
+            !results.is_empty(),
+            "Should find results for term '{}'",
+            term
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
This PR adds a failing test case that reproduces issue #368 where the trigram index is not properly populated during repository ingestion, causing validation failures.

## Background
Issue #368 reports that the trigram index isn't being populated during `ingest-repo` command, leading to search validation failures. Through investigation, I've confirmed that:
- The code structure is correct (rebuild_indices properly calls insert_with_content)
- The trigram index implementation is correct
- But validation still fails, indicating a persistence or timing issue

## Changes
- Added `tests/test_trigram_issue_368.rs` - a comprehensive test that reproduces the issue
- The test intentionally FAILS to demonstrate the bug

## Test Details
The test:
1. Creates documents in storage
2. Attempts to rebuild indices with content (mimicking what ingest-repo does)
3. Verifies that the trigram index should be populated
4. Currently fails at step 3, confirming the issue

## Investigation Findings
Through deep code analysis, I found that:
- ✅ The `rebuild_indices()` function is being called after ingestion
- ✅ It correctly calls `insert_with_content()` for the trigram index
- ✅ The trigram index properly requires content (rejects insert() without content)
- ❌ Despite correct logic, validation fails - suggesting a persistence/timing issue

## Next Steps
This test provides a minimal reproduction case for debugging. The next phase would involve:
1. Investigating why the correctly-implemented code isn't persisting the index
2. Checking for race conditions or unflushed buffers
3. Examining the validation logic's expectations

## Related Issues
- Addresses #368
- Part of the Codebase Intelligence Platform transition (#374)

## Test Plan
Run the new test to see it fail (expected behavior):
```bash
cargo test test_trigram_index_population_after_rebuild
```

🤖 Generated with [Claude Code](https://claude.ai/code)