### PR TITLE
feat: automatically build dependency graph during repository ingestion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1527,12 +1527,14 @@ async fn main() -> Result<()> {
 
                 #[cfg(feature = "tree-sitter-parsing")]
                 let result = if config.options.extract_symbols {
-                    // Use binary format for efficient symbol storage
+                    // Use binary format for efficient symbol storage with automatic dependency graph building
                     let symbol_db_path = cli.db_path.join("symbols.kota");
-                    ingester.ingest_with_binary_symbols(
+                    let graph_db_path = cli.db_path.join("dependency_graph.bin");
+                    ingester.ingest_with_binary_symbols_and_relationships(
                         &repo_path,
                         &mut *storage,
                         &symbol_db_path,
+                        &graph_db_path,
                         Some(progress_callback),
                     ).await?
                 } else {


### PR DESCRIPTION
## Summary
Resolves #373 by automatically building dependency graphs during repository ingestion.

- Repository ingestion now creates `dependency_graph.bin` by default 
- Relationship queries work immediately after ingestion without manual steps
- Added comprehensive progress indicators for all graph construction phases
- Fixed serialization format compatibility between ingestion and query engines

## Changes Made

### Core Implementation
- **main.rs**: Updated to use `ingest_with_binary_symbols_and_relationships` instead of basic binary symbol ingestion
- **git/ingestion.rs**: Enhanced progress reporting and fixed serialization format to use bincode

### Progress Indicators
- "Building dependency graph from extracted symbols..."
- "Analyzing X source files for dependencies..."  
- "Found X relationships between symbols"
- "Persisting dependency graph to disk..."
- "✅ Dependency graph built: X relationships extracted in Yms"

### Bug Fixes
- Fixed progress callback propagation through all ingestion phases
- Corrected serialization format from JSON to bincode for compatibility with existing load functions

## Test Results
✅ Successfully tested with sample repository:
- 7 symbols extracted 
- 3 relationships found between symbols
- Relationship queries (`find-callers`, `impact-analysis`) work immediately after ingestion
- No manual dependency graph building step required

## Breaking Change
⚠️ **BREAKING CHANGE**: Repository ingestion now creates `dependency_graph.bin` by default, which may affect disk usage and ingestion time slightly. The functionality is automatic and transparent to users.

🤖 Generated with [Claude Code](https://claude.ai/code)