### PR TITLE
fix(mcp): add missing 'enable_document_tools' field to configuration (#407)

### DIFF
--- a/kotadb-mcp-dev.toml
+++ b/kotadb-mcp-dev.toml
@@ -21,10 +21,8 @@ server_name = "kotadb"
 server_version = "0.5.0"
 
 # Tool Categories
-enable_codebase_tools = true
-enable_symbol_tools = true
+enable_document_tools = true
 enable_search_tools = true
-enable_analysis_tools = true
 
 [logging]
 level = "debug"


### PR DESCRIPTION
## Summary
- Fixes MCP server configuration parsing error by adding missing `enable_document_tools` field
- Removes unsupported configuration fields from kotadb-mcp-dev.toml
- Aligns development config with expected MCPProtocolConfig structure

## Changes
- Added `enable_document_tools = true` to [mcp] section in kotadb-mcp-dev.toml
- Removed unsupported fields: `enable_codebase_tools`, `enable_symbol_tools`, `enable_analysis_tools`
- Kept only the two fields defined in MCPProtocolConfig struct: `enable_document_tools` and `enable_search_tools`

## Test Plan
- [x] Built MCP server with `cargo build --bin mcp_server --features mcp-server`
- [x] Verified server can parse configuration (no more "missing field" error)
- [x] Ran all tests with `cargo test` - all 248 tests pass
- [x] Checked code with `cargo check --all-targets --features mcp-server`

## Context
This issue was discovered during dogfooding while testing MCP server integration with Claude Code. The configuration file was missing a required field that's defined in the MCPProtocolConfig struct.

Fixes #407

🤖 Generated with [Claude Code](https://claude.ai/code)