### PR TITLE
fix: reduce default logging verbosity to prevent CLI spam

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ EXAMPLES:
   kotadb serve --port 8080"
 )]
 struct Cli {
-    /// Enable verbose logging (DEBUG level). Default is WARN level.
+    /// Enable verbose logging (DEBUG level). Default is ERROR level to prevent log spam.
     #[arg(short, long, global = true, conflicts_with = "quiet")]
     verbose: bool,
 

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -39,8 +39,9 @@ pub fn init_logging_with_level(verbose: bool, quiet: bool) -> Result<()> {
         // In verbose mode, show debug info for kotadb and info for others
         EnvFilter::new("kotadb=debug,info")
     } else {
-        // Default: warnings for kotadb and others
-        EnvFilter::new("kotadb=warn,warn")
+        // Default: only show errors to avoid log spam in production CLI usage
+        // Users can enable more logging with --verbose or RUST_LOG env var
+        EnvFilter::new("error")
     };
 
     // Quiet flag takes precedence over environment variable


### PR DESCRIPTION
## Summary
- Changed default logging level from WARN to ERROR to prevent log spam in production CLI usage
- Updated CLI help text to accurately reflect the new default logging level  
- Users can still enable verbose logging with `--verbose` flag or `RUST_LOG` environment variable

## Problem
The CLI was outputting excessive logs by default, making it practically unusable for production. This was identified as a critical blocker for the September 10th launch.

## Solution
Modified the `init_logging_with_level` function in `src/observability.rs` to use ERROR level as the default instead of WARN level. This ensures minimal output by default while preserving the ability for users to opt into more verbose logging when needed.

## Test Plan
✅ Tested default mode - no logging output (only command results)
✅ Tested `--verbose` flag - shows debug/info logs as expected
✅ Tested `RUST_LOG=info` env var - overrides default as expected
✅ All existing tests pass
✅ Code formatting and linting checks pass

Fixes #496

🤖 Generated with Claude Code (https://claude.ai/code)